### PR TITLE
Add legacy API

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
   "homepage": "https://github.com/input-output-hk/icaraus-poc-backend-service#readme",
   "dependencies": {
     "axios": "0.18.0",
+    "bignum": "^0.13.0",
     "bunyan": "1.8.12",
+    "cardano-crypto.js": "^4.2.1",
     "claudia-api-builder": "4.0.2",
     "config": "1.30.0",
     "dotenv": "^6.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-require('dotenv').config()
+require('dotenv').config();
 
 const server = require('./server');
 // Don't check client certs

--- a/src/legacy-routes.js
+++ b/src/legacy-routes.js
@@ -1,0 +1,175 @@
+// @flow
+
+import type { ServerConfig } from 'icarus-backend'; // eslint-disable-line
+
+const moment = require('moment');
+const cardanoCrypto = require('cardano-crypto.js');
+const bignum = require('bignum');
+const _ = require('lodash');
+
+const withPrefix = route => `/api${route}`;
+const invalidAddress = 'Invalid Cardano address!';
+const invalidTx = 'Invalid transaction id!';
+
+const arraySum = (numbers) => numbers.reduce((acc, val) => acc.add(bignum(val)), bignum(0));
+
+const txAddressCoins = (addresses, amounts, address) => arraySum(_.zip(addresses, amounts)
+  .filter((pair) => pair[0] === address)
+  .map((pair) => _.nth(pair, 1)));
+
+const txToAddressInfo = (row) => ({
+  ctbId: row.hash,
+  ctbTimeIssued: moment(row.time).unix(),
+  ctbInputs: row.inputs_address.map(
+    (addr, i) => [addr, { getCoin: row.inputs_amount[i] }]),
+  ctbOutputs: row.outputs_address.map(
+    (addr, i) => [addr, { getCoin: row.outputs_amount[i] }]),
+  ctbInputSum: {
+    getCoin: `${arraySum(row.inputs_amount)}`,
+  },
+  ctbOutputSum: {
+    getCoin: `${arraySum(row.outputs_amount)}`,
+  },
+});
+
+/**
+ * This endpoint returns a summary for a given address
+ * @param {*} db Database
+ * @param {*} Server Server Config Object
+ */
+const addressSummary = (dbApi: any, { logger }: ServerConfig) => async (req: any,
+) => {
+  const { address } = req.params;
+  if (!cardanoCrypto.isValidAddress(address)) {
+    return { Left: invalidAddress };
+  }
+  const result = await dbApi.addressSummary(address);
+  const transactions = result.rows;
+  const totalAddressIn = transactions.reduce((acc, tx) =>
+    acc.add(txAddressCoins(tx.outputs_address, tx.outputs_amount, address)), bignum(0));
+  const totalAddressOut = transactions.reduce((acc, tx) =>
+    acc.add(txAddressCoins(tx.inputs_address, tx.inputs_amount, address)), bignum(0));
+
+  const right = {
+    caAddress: address,
+    caType: 'CPubKeyAddress',
+    caTxNum: transactions.length,
+    caBalance: {
+      getCoin: `${totalAddressIn.sub(totalAddressOut)}`,
+    },
+    caTxList: transactions.map(txToAddressInfo),
+  };
+  logger.debug('[addressSummary] result calculated');
+  return { Right: right };
+};
+
+/**
+ * This endpoint returns a transaction summary for a given hash
+ * @param {*} db Database
+ * @param {*} Server Server Config Object
+ */
+const txSummary = (dbApi: any, { logger }: ServerConfig) => async (req: any,
+) => {
+  const { tx } = req.params;
+  const result = await dbApi.txSummary(tx);
+  if (result.rows.length === 0) {
+    return { Left: invalidTx };
+  }
+  const row = result.rows[0];
+  const totalInput = arraySum(row.inputs_amount);
+  const totalOutput = arraySum(row.outputs_amount);
+  const epoch0 = 1506203091;
+  const slotSeconds = 20;
+  const epochSlots = 21600;
+  const blockTime = moment(row.time).unix();
+  const right = {
+    ctsId: row.hash,
+    ctsTxTimeIssued: blockTime,
+    ctsBlockTimeIssued: blockTime,
+    ctsBlockHeight: Number(row.block_num),
+    ctsBlockEpoch: Math.floor((blockTime - epoch0) / (epochSlots * slotSeconds)),
+    ctsBlockSlot: Math.floor((blockTime - epoch0) / slotSeconds) % epochSlots,
+    ctsBlockHash: row.block_hash,
+    ctsRelayedBy: null,
+    ctsTotalInput: {
+      getCoin: `${totalInput}`,
+    },
+    ctsTotalOutput: {
+      getCoin: `${totalOutput}`,
+    },
+    ctsFees: {
+      getCoin: `${totalInput.sub(totalOutput)}`,
+    },
+    ctsInputs: row.inputs_address.map(
+      (addr, i) => [addr, { getCoin: row.inputs_amount[i] }]),
+    ctsOutputs: row.outputs_address.map(
+      (addr, i) => [addr, { getCoin: row.outputs_amount[i] }]),
+  };
+  logger.debug('[txSummary] result calculated');
+  return { Right: right };
+};
+
+/**
+ * This endpoint returns a raw transaction body for a given hash
+ * @param {*} db Database
+ * @param {*} Server Server Config Object
+ */
+const txRaw = (dbApi: any, { logger }: ServerConfig) => async (req: any,
+) => {
+  const { tx } = req.params;
+  const result = await dbApi.txSummary(tx);
+  if (result.rows.length === 0) {
+    return { Left: invalidTx };
+  }
+  logger.debug('[txRaw] result calculated');
+  return { Right: result.rows[0].tx_body };
+};
+
+/**
+ * This endpoint returns unspent transaction outputs for a given array of addresses
+ * @param {*} db Database
+ * @param {*} Server Server Config Object
+ */
+const unspentTxOutputs = (dbApi: any, { logger, apiConfig }: ServerConfig) => async (req: any,
+) => {
+  const addresses = req.body;
+  const limit = apiConfig.addressesRequestLimit;
+  if (!addresses || addresses.length === 0 || addresses.length > limit) {
+    return { Left: `Addresses request length should be (0, ${limit}]` };
+  }
+  if (addresses.some((addr) => !cardanoCrypto.isValidAddress(addr))) {
+    return { Left: invalidAddress };
+  }
+  const result = await dbApi.utxoLegacy(addresses);
+  const mappedRows = result.rows.map((row) => {
+    const coins = row.cuCoins;
+    const newRow = row;
+    newRow.cuCoins = { getCoin: coins };
+    return newRow;
+  });
+  logger.debug('[unspentTxOutputs] result calculated');
+  return { Right: mappedRows };
+};
+
+module.exports = {
+  addressSummary: {
+    method: 'get',
+    path: withPrefix('/addresses/summary/:address'),
+    handler: addressSummary,
+  },
+  txSummary: {
+    method: 'get',
+    path: withPrefix('/txs/summary/:tx'),
+    handler: txSummary,
+  },
+  txRaw: {
+    method: 'get',
+    path: withPrefix('/txs/raw/:tx'),
+    handler: txRaw,
+  },
+  unspentTxOutputs: {
+    method: 'post',
+    path: withPrefix('/bulk/addresses/utxo'),
+    handler: unspentTxOutputs,
+  },
+};

--- a/src/routes.js
+++ b/src/routes.js
@@ -14,7 +14,7 @@ const moment = require('moment');
 const { version } = require('../package.json');
 const errs = require('restify-errors');
 
-const withPrefix = route => `/api${route}`;
+const withPrefix = route => `/api/v2${route}`;
 
 /**
  * This method validates addresses request body

--- a/src/server.js
+++ b/src/server.js
@@ -10,11 +10,13 @@ const corsMiddleware = require('restify-cors-middleware');
 const restifyBunyanLogger = require('restify-bunyan-logger');
 const config = require('config');
 const routes = require('./routes');
+const legacyRoutes = require('./legacy-routes');
 const createDB = require('./db');
 const dbApi = require('./db-api');
 const importerApi = require('./importer-api');
 const configCleanup = require('./cleanup');
 const manageConnections = require('./ws-connections');
+const _ = require('lodash');
 
 const serverConfig = config.get('server');
 const { logger, importerSendTxEndpoint } = serverConfig;
@@ -52,7 +54,7 @@ async function createServer() {
   server.use(restify.plugins.bodyParser());
   server.on('after', restifyBunyanLogger());
 
-  Object.values(routes).forEach(({ method, path, handler }: any) => {
+  Object.values(_.merge(routes, legacyRoutes)).forEach(({ method, path, handler }: any) => {
     server[method](path, async (req, res, next) => {
       try {
         const result = await handler(

--- a/test/integration/test-utils.js
+++ b/test/integration/test-utils.js
@@ -8,7 +8,7 @@ const createServer = require('../../src/server');
 function api(server): Hippie {
   return hippie(server)
     .json()
-    .base('http://localhost:8080/api');
+    .base('http://localhost:8080/api/v2');
 }
 
 /**

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -67,8 +67,8 @@ describe('Routes', () => {
   }
 
   describe('Healthcheck', () => {
-    it('should have GET as method and /api/healthcheck as path', () => {
-      validateMethodAndPath(routes.healthCheck, 'get', '/api/healthcheck');
+    it('should have GET as method and /api/v2/healthcheck as path', () => {
+      validateMethodAndPath(routes.healthCheck, 'get', '/api/v2/healthcheck');
     });
 
     it('should return package.json version as response', async () => {
@@ -79,11 +79,11 @@ describe('Routes', () => {
   });
 
   describe('Filter Used Addresses', () => {
-    it('should have POST as method and /api/addresses/filterUsed as path', () => {
+    it('should have POST as method and /api/v2/addresses/filterUsed as path', () => {
       validateMethodAndPath(
         routes.filterUsedAddresses,
         'post',
-        '/api/addresses/filterUsed',
+        '/api/v2/addresses/filterUsed',
       );
     });
 
@@ -104,11 +104,11 @@ describe('Routes', () => {
   });
 
   describe('UTXO for addresses', () => {
-    it('should have POST as method and /txs/utxoForAddresses as path', () => {
+    it('should have POST as method and /api/v2/txs/utxoForAddresses as path', () => {
       validateMethodAndPath(
         routes.utxoForAddresses,
         'post',
-        '/api/txs/utxoForAddresses',
+        '/api/v2/txs/utxoForAddresses',
       );
     });
 
@@ -129,11 +129,11 @@ describe('Routes', () => {
   });
 
   describe('UTXO Sum for addresses', () => {
-    it('should have POST as method and /txs/utxoSumForAddresses as path', () => {
+    it('should have POST as method and api/v2//txs/utxoSumForAddresses as path', () => {
       validateMethodAndPath(
         routes.utxoSumForAddresses,
         'post',
-        '/api/txs/utxoSumForAddresses',
+        '/api/v2/txs/utxoSumForAddresses',
       );
     });
 
@@ -154,11 +154,11 @@ describe('Routes', () => {
   });
 
   describe('Transactions history', () => {
-    it('should have POST as method and /txs/history as path', () => {
+    it('should have POST as method and /api/v2/txs/history as path', () => {
       validateMethodAndPath(
         routes.transactionsHistory,
         'post',
-        '/api/txs/history',
+        '/api/v2/txs/history',
       );
     });
 
@@ -186,11 +186,11 @@ describe('Routes', () => {
   });
 
   describe('Signed Transaction', () => {
-    it('should have POST as method and /txs/signed as path', () => {
+    it('should have POST as method and /api/v2/txs/signed as path', () => {
       validateMethodAndPath(
         routes.signedTransaction,
         'post',
-        '/api/txs/signed',
+        '/api/v2/txs/signed',
       );
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -572,6 +572,21 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bignum@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/bignum/-/bignum-0.13.0.tgz#3e8ad9d1bc1d28094a3c0b957a91e8b7c7a2882e"
+  integrity sha512-OYaAUVBxVXG2JEupL/BQ95rp8yr3WPe66YtywtJ+86YXOleggw8xtLU0360d4MZE3x+ROZ89qihgFFxGabfuhQ==
+  dependencies:
+    bindings "~1.3.0"
+    nan "~2.10.0"
+    prebuild-install "~4.0.0"
+    safe-buffer "~5.1.2"
+
+bignumber.js@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.0.1.tgz#5d419191370fb558c64e3e5f70d68e5947138832"
+  integrity sha512-zAySveTJXkgLYCBi0b14xzfnOs+f3G6x36I8w2a1+PFQpWk/dp0mI0F+ZZK2bu+3ELewDcSyP+Cfq++NcHX7sg==
+
 bin-links@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/bin-links/-/bin-links-1.1.2.tgz#fb74bd54bae6b7befc6c6221f25322ac830d9757"
@@ -587,6 +602,19 @@ binary-extensions@^1.0.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.12.0.tgz#c2d780f53d45bba8317a8902d4ceeaf3a6385b14"
   integrity sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==
+
+bindings@~1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.1.tgz#21fc7c6d67c18516ec5aaa2815b145ff77b26ea5"
+  integrity sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==
+
+bip39-light@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/bip39-light/-/bip39-light-1.0.7.tgz#06a72f251b89389a136d3f177f29b03342adc5ba"
+  integrity sha512-WDTmLRQUsiioBdTs9BmSEmkJza+8xfJmptsNJjxnoq3EydSa/ZBXT6rm66KoT3PJIRYMnhSKNR7S9YL1l7R40Q==
+  dependencies:
+    create-hash "^1.1.0"
+    pbkdf2 "^3.0.9"
 
 bl@^1.0.0:
   version "1.2.2"
@@ -836,10 +864,28 @@ capture-stack-trace@^1.0.0:
   resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d"
   integrity sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==
 
+cardano-crypto.js@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/cardano-crypto.js/-/cardano-crypto.js-4.2.1.tgz#ceddd9614dab17845b76e75751f537664854320d"
+  integrity sha512-IBA7I7GFi8lagCE6T9RtleVxRsqgvj299vy3F8W2h6Q+a5fNFxxTt7jBXT0DefBZTedeHOqjmp/rTFZ/ETNZzA==
+  dependencies:
+    bip39-light "^1.0.7"
+    cbor "^4.1.1"
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+cbor@^4.1.1:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-4.1.3.tgz#c6b69611ff8f916f0391f43a16291c7ca297d2f4"
+  integrity sha512-yyKb++PWB2Xhvq7CjUuyD+wu2pG8le6y5KTCPmq1plflkcsj96iYXKaaYqLAkm7bmhnNKM0VIpkixRwwHVP0RA==
+  dependencies:
+    bignumber.js "^8.0.1"
+    commander "^2.19.0"
+    json-text-sequence "^0.1"
+    nofilter "^1.0.1"
 
 chai-as-promised@7.1.1:
   version "7.1.1"
@@ -931,6 +977,14 @@ cidr-regex@^2.0.10:
   integrity sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==
   dependencies:
     ip-regex "^2.1.0"
+
+cipher-base@^1.0.1, cipher-base@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
+  integrity sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 circular-json@^0.3.1:
   version "0.3.3"
@@ -1082,6 +1136,11 @@ commander@2.15.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
   integrity sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
 
+commander@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+
 commander@~2.17.1:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
@@ -1211,6 +1270,29 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
+create-hash@^1.1.0, create-hash@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
+  integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
+  dependencies:
+    cipher-base "^1.0.1"
+    inherits "^2.0.1"
+    md5.js "^1.3.4"
+    ripemd160 "^2.0.1"
+    sha.js "^2.4.0"
+
+create-hmac@^1.1.4:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
+  integrity sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
+  dependencies:
+    cipher-base "^1.0.3"
+    create-hash "^1.1.0"
+    inherits "^2.0.1"
+    ripemd160 "^2.0.0"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
+
 cross-spawn@^4:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
@@ -1313,6 +1395,13 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
+decompress-response@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
+  integrity sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=
+  dependencies:
+    mimic-response "^1.0.0"
+
 deep-eql@^3.0.0, deep-eql@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
@@ -1376,12 +1465,17 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+delimit-stream@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/delimit-stream/-/delimit-stream-0.1.0.tgz#9b8319477c0e5f8aeb3ce357ae305fc25ea1cd2b"
+  integrity sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs=
+
 detect-indent@~5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
-detect-libc@^1.0.2:
+detect-libc@^1.0.2, detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
@@ -1741,6 +1835,11 @@ expand-range@^1.8.1:
   integrity sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=
   dependencies:
     fill-range "^2.1.0"
+
+expand-template@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-1.1.1.tgz#981f188c0c3a87d2e28f559bc541426ff94f21dd"
+  integrity sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -2140,6 +2239,11 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
+  integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
@@ -2345,6 +2449,14 @@ has@^1.0.1:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+hash-base@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.0.4.tgz#5fc8686847ecd73499403319a6b0a3f3f6ae4918"
+  integrity sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 he@1.1.1:
   version "1.1.1"
@@ -2969,6 +3081,13 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
+json-text-sequence@^0.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/json-text-sequence/-/json-text-sequence-0.1.1.tgz#a72f217dc4afc4629fff5feb304dc1bd51a2f3d2"
+  integrity sha1-py8hfcSvxGKf/1/rME3BvVGi89I=
+  dependencies:
+    delimit-stream "0.1.0"
+
 json5@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.4.0.tgz#054352e4c4c80c86c0923877d449de176a732c8d"
@@ -3291,6 +3410,15 @@ md5-o-matic@^0.1.1:
   resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
   integrity sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=
 
+md5.js@^1.3.4:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
+  integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+    safe-buffer "^5.1.2"
+
 meant@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/meant/-/meant-1.0.1.tgz#66044fea2f23230ec806fb515efea29c44d2115d"
@@ -3369,6 +3497,11 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
+
+mimic-response@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
+  integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
 minimal-request-promise@^1.1.0:
   version "1.5.0"
@@ -3532,6 +3665,11 @@ nan@^2.10.0, nan@^2.9.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
   integrity sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==
 
+nan@~2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+  integrity sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -3583,6 +3721,13 @@ nise@^1.3.3:
     lolex "^2.3.2"
     path-to-regexp "^1.7.0"
     text-encoding "^0.6.4"
+
+node-abi@^2.2.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.5.0.tgz#942e1a78bce764bc0c1672d5821e492b9d032052"
+  integrity sha512-9g2twBGSP6wIR5PW7tXvAWnEWKJDH/VskdXp168xsw9VVxpEGov8K4jsP4/VeoC7b2ZAyzckvMCuQuQlw44lXg==
+  dependencies:
+    semver "^5.4.1"
 
 node-fetch-npm@^2.0.2:
   version "2.0.2"
@@ -3642,6 +3787,16 @@ nodemon@1.17.5:
     touch "^3.1.0"
     undefsafe "^2.0.2"
     update-notifier "^2.3.0"
+
+nofilter@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-1.0.1.tgz#5e6e9a7666a293b092791e7cb58c74b125f1cd11"
+  integrity sha512-p2J1rODXWkqM5NAT7TMUmKGAcnUreT4uSTUar+vdrquOXV5vn8oHW2hBU0LeQSh6nwz4xkxcpRE89UGk+eQUcw==
+
+noop-logger@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
+  integrity sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
 
 "nopt@2 || 3":
   version "3.0.6"
@@ -3931,7 +4086,7 @@ npm@^6.1.0:
     worker-farm "^1.6.0"
     write-file-atomic "^2.3.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", "npmlog@2 || ^3.1.0 || ^4.0.0", npmlog@^4.0.2, npmlog@~4.1.2:
+"npmlog@0 || 1 || 2 || 3 || 4", "npmlog@2 || ^3.1.0 || ^4.0.0", npmlog@^4.0.1, npmlog@^4.0.2, npmlog@~4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -4272,6 +4427,17 @@ pathval@^1.0.0, pathval@~1.1.0:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
   integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
 
+pbkdf2@^3.0.9:
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
+  integrity sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==
+  dependencies:
+    create-hash "^1.1.2"
+    create-hmac "^1.1.4"
+    ripemd160 "^2.0.1"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
+
 peek-stream@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/peek-stream/-/peek-stream-1.1.3.tgz#3b35d84b7ccbbd262fff31dc10da56856ead6d67"
@@ -4392,6 +4558,27 @@ postgres-interval@^1.1.0:
   integrity sha512-fC3xNHeTskCxL1dC8KOtxXt7YeFmlbTYtn7ul8MkVERuTmf7pI4DrkAxcw3kh1fQ9uz4wQmd03a1mRiXUZChfQ==
   dependencies:
     xtend "^4.0.0"
+
+prebuild-install@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-4.0.0.tgz#206ce8106ce5efa4b6cf062fc8a0a7d93c17f3a8"
+  integrity sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==
+  dependencies:
+    detect-libc "^1.0.3"
+    expand-template "^1.0.2"
+    github-from-package "0.0.0"
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
+    node-abi "^2.2.0"
+    noop-logger "^0.1.1"
+    npmlog "^4.0.1"
+    os-homedir "^1.0.1"
+    pump "^2.0.1"
+    rc "^1.1.6"
+    simple-get "^2.7.0"
+    tar-fs "^1.13.0"
+    tunnel-agent "^0.6.0"
+    which-pm-runs "^1.0.0"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -4951,6 +5138,14 @@ rimraf@~2.4.0:
   dependencies:
     glob "^6.0.1"
 
+ripemd160@^2.0.0, ripemd160@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
+  integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+
 run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
@@ -4977,7 +5172,7 @@ rx-lite@*, rx-lite@^4.0.8:
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
   integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1, safe-buffer@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -5076,6 +5271,14 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
+sha.js@^2.4.0, sha.js@^2.4.8:
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
+
 sha@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/sha/-/sha-2.0.1.tgz#6030822fbd2c9823949f8f72ed6411ee5cf25aae"
@@ -5110,6 +5313,20 @@ signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+simple-concat@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
+  integrity sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=
+
+simple-get@^2.7.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-2.8.1.tgz#0e22e91d4575d87620620bc91308d57a77f44b5d"
+  integrity sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==
+  dependencies:
+    decompress-response "^3.3.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
 
 sinon@5.0.10:
   version "5.0.10"
@@ -5510,7 +5727,7 @@ table@4.0.2:
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
-tar-fs@^1.14.0:
+tar-fs@^1.13.0, tar-fs@^1.14.0:
   version "1.16.3"
   resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-1.16.3.tgz#966a628841da2c4010406a82167cbd5e0c72d509"
   integrity sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==
@@ -5922,6 +6139,11 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+
+which-pm-runs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
+  integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
 which@1, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
Move the new API to /api/v2 prefix and add legacy API intended to provide the same functionality as the old API at explorer.cardanolite.com to /api prefix. Some test files were modified to use /api/v2 prefix for new requests. (#1)