### PR TITLE
Fix healthcheck

### DIFF
--- a/src/healthcheck.js
+++ b/src/healthcheck.js
@@ -25,18 +25,18 @@ async function start(db: any) {
   let prevBestBlock = 0
 
   while (true) { // eslint-disable-line
-    const currentBestBlock = await fetchBestBlock(db) // eslint-disable-line
+    const currentBestBlock = Number(await fetchBestBlock(db)) // eslint-disable-line
     // compare block number to the expected value based on the official blockchain explorer data
-    let behind = false
-    axios.get('https://cardanoexplorer.com/api/blocks/pages')
+    const behind = await axios.get('https://cardanoexplorer.com/api/blocks/pages') // eslint-disable-line
       .then(response => {
         const pages = response.data.Right[0]
         const items = response.data.Right[1].length
         const explorerBlock = ((pages - 1) * 10) + items
-        behind = (explorerBlock - currentBestBlock > 3)
+        return (explorerBlock - currentBestBlock > 3)
       })
       .catch(error => {
         logger.debug(error)
+        return false
       })
     // the database is considered up to date if the block number changed and is not too far behind
     const upToDate = !(prevBestBlock === currentBestBlock) && !behind

--- a/src/healthcheck.js
+++ b/src/healthcheck.js
@@ -22,10 +22,9 @@ async function start(db: any) {
   rtm.start()
 
   let healthy = true
-  let prevBestBlock = await fetchBestBlock(db)
+  let prevBestBlock = 0
 
   while (true) { // eslint-disable-line
-    await delay(70000) // eslint-disable-line
     const currentBestBlock = await fetchBestBlock(db) // eslint-disable-line
     // compare block number to the expected value based on the official blockchain explorer data
     let behind = false
@@ -47,13 +46,14 @@ async function start(db: any) {
       healthy = upToDate
       const message = upToDate ? 'Database is updating again.' : 'Database did not update!'
       logger.info(message)
-      rtm.sendMessage(message, channelId)
+      rtm.sendMessage(`${process.env.name}: ${message}`, channelId)
         .then(() => {
           logger.debug('Message was sent without problems.')
         })
     }
 
     prevBestBlock = currentBestBlock
+    await delay(70000) // eslint-disable-line
   }
 }
 


### PR DESCRIPTION
Move the delay to the end of the healthcheck loop so the first check
is done immediately instead of after 70 seconds. Add process name to
the Slack message.