### PR TITLE
Add endpoints for submitting transactions to pm2

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -11,6 +11,7 @@
     "channelId": "SLACK_CHANNEL"
   },
   "server": {
-    "port": "PORT"
+    "port": "PORT",
+    "importerSendTxEndpoint": "IMPORTER_ENDPOINT"
   }
 }

--- a/pm2.config.js
+++ b/pm2.config.js
@@ -15,6 +15,7 @@ module.exports = {
     merge_logs: true,
     env: {
       PORT: 8080,
+      IMPORTER_ENDPOINT: 'http://localhost:8201/api/txs/signed',
       DB: 'icarus_mainnet_1',
       NODE_ENV: 'production',
     },
@@ -38,6 +39,7 @@ module.exports = {
     merge_logs: true,
     env: {
       PORT: 8081,
+      IMPORTER_ENDPOINT: 'http://localhost:8202/api/txs/signed',
       DB: 'icarus_mainnet_2',
       NODE_ENV: 'production',
     },


### PR DESCRIPTION
Override importerSendTxEndpoint via pm2 config since the two instances
can't use the same port. Switch to http since AWS doesn't support https.