### PR TITLE
Add bulk address summary endpoint

### DIFF
--- a/src/db-api.js
+++ b/src/db-api.js
@@ -80,6 +80,20 @@ const addressSummary = (db: Pool) => async (address: string): Promise<ResultSet>
   })
 
 /**
+ * Queries DB looking for successful transactions associated with any of the given addresses.
+ * @param {Db Object} db
+ * @param {Array<Address>} addresses
+ */
+const bulkAddressSummary = (db: Pool) => async (addresses: Array<string>): Promise<ResultSet> =>
+  db.query({
+    text: `SELECT * FROM "txs"
+      WHERE hash = ANY (SELECT tx_hash FROM "tx_addresses" WHERE address = ANY($1))
+      AND tx_state = $2
+      ORDER BY time DESC`,
+    values: [addresses, 'Successful'],
+  })
+
+/**
 * Queries TXS table looking for a successful transaction with a given hash
 * @param {Db Object} db
 * @param {*} tx
@@ -128,6 +142,7 @@ export default (db: Pool): DbApi => ({
   bestBlock: bestBlock(db),
   // legacy
   addressSummary: addressSummary(db),
+  bulkAddressSummary: bulkAddressSummary(db),
   txSummary: txSummary(db),
   utxoLegacy: utxoLegacy(db),
   lastTxs: lastTxs(db),

--- a/src/db-api.js
+++ b/src/db-api.js
@@ -69,17 +69,6 @@ const transactionsHistoryForAddresses = (db: Pool) => async (
 // The remaining queries should be used only for the purposes of the legacy API!
 
 /**
- * Queries DB looking for successful transactions associated with the given address
- * @param {Db Object} db
- * @param {Address} address
- */
-const addressSummary = (db: Pool) => async (address: string): Promise<ResultSet> =>
-  db.query({
-    text: 'SELECT * FROM "txs" WHERE hash = ANY (SELECT tx_hash from "tx_addresses" WHERE address = $1) AND tx_state = $2',
-    values: [address, 'Successful'],
-  })
-
-/**
  * Queries DB looking for successful transactions associated with any of the given addresses.
  * @param {Db Object} db
  * @param {Array<Address>} addresses
@@ -141,7 +130,6 @@ export default (db: Pool): DbApi => ({
   transactionsHistoryForAddresses: transactionsHistoryForAddresses(db),
   bestBlock: bestBlock(db),
   // legacy
-  addressSummary: addressSummary(db),
   bulkAddressSummary: bulkAddressSummary(db),
   txSummary: txSummary(db),
   utxoLegacy: utxoLegacy(db),

--- a/src/legacy-routes.js
+++ b/src/legacy-routes.js
@@ -43,7 +43,7 @@ const addressSummary = (dbApi: any, { logger }: ServerConfig) => async (req: any
   if (!isValidAddress(address)) {
     return { Left: invalidAddress }
   }
-  const result = await dbApi.addressSummary(address)
+  const result = await dbApi.bulkAddressSummary([address])
   const transactions = result.rows
   const totalAddressIn = transactions.reduce((acc, tx) =>
     acc.plus(txAddressCoins(tx.outputs_address, tx.outputs_amount, address)), Big(0))


### PR DESCRIPTION
/api/bulk/addresses/summary accepts POST requests with arrays of
addresses. If the array is empty, too long or any of the addresses is
invalid, Left is returned. Otherwise, the addresses, the number of
transactions and the transaction data are returned. The transactions
are ordered by time, descending. Replace addressSummary function
with bulkAddressSummary. Closes #30 