### PR TITLE
Set CORS header

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -7,5 +7,6 @@ module.exports = {
       txHistoryResponseLimit: 20,
     },
     disableHealthcheck: false,
+    allowCredentials: false,
   },
 }

--- a/config/production.js
+++ b/config/production.js
@@ -5,7 +5,7 @@ module.exports = {
   appName: 'icarus-poc-backend-service',
   server: {
     corsEnabledFor: ['https://adalite.io', 'https://*.adalite.io', 'http://*.adalite.io',
-     'https://adalite-staging.herokuapp.com', 'http://localhost:*'],
+     'https://adalite-staging.herokuapp.com', 'http://localhost:*', 'https://localhost:*'],
     allowCredentials: true,
     logger: raw(consoleLogger('error')),
     port: 8080,

--- a/config/production.js
+++ b/config/production.js
@@ -4,7 +4,9 @@ const { consoleLogger } = require('../src/logger')
 module.exports = {
   appName: 'icarus-poc-backend-service',
   server: {
-    corsEnabledFor: ['*'],
+    corsEnabledFor: ['https://adalite.io', 'https://*.adalite.io', 'http://*.adalite.io',
+     'https://adalite-staging.herokuapp.com', 'http://localhost:*'],
+    allowCredentials: true,
     logger: raw(consoleLogger('error')),
     port: 8080,
     apiConfig: {

--- a/src/server.js
+++ b/src/server.js
@@ -17,7 +17,9 @@ import healthCheck from './healthcheck'
 import responseGuard from './middleware/response-guard'
 
 const serverConfig = config.get('server')
-const { logger, importerSendTxEndpoint, disableHealthcheck } = serverConfig
+const {
+  logger, importerSendTxEndpoint, disableHealthcheck, corsEnabledFor, allowCredentials,
+} = serverConfig
 
 async function createServer() {
   const db = await createDB(config.get('db'))
@@ -32,7 +34,7 @@ async function createServer() {
     healthCheck(db)
   }
 
-  const cors = corsMiddleware({ origins: serverConfig.corsEnabledFor })
+  const cors = corsMiddleware({ origins: corsEnabledFor, credentials: allowCredentials })
   server.pre(cors.preflight)
   server.use(cors.actual)
   server.use(restify.plugins.bodyParser())


### PR DESCRIPTION
For production, allow only adalite.io, staging and localhost as origins.
Add Access-Control-Allow-Credentials header. Closes #32 