### PR TITLE
Add global error logging to server

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "flow": "flow",
     "build": "rm -rf build/ && flow-remove-types ./src/ -d ./build/ --all --pretty && babel ./build/ --out-dir ./build/",
-    "start": "NODE_ENV=production node ./build/index.js",
+    "start": "NODE_ENV=production node ./build/index.js | bunyan",
     "dev": "yarn build && export NODE_ENV=develop && nodemon ./build/index.js | bunyan",
     "staging": "yarn build && export NODE_ENV=staging && nodemon ./build/index.js | bunyan",
     "eslint": "eslint ./src",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,13 @@
 import '@babel/polyfill'
+import config from 'config'
 import './config'
 import server from './server'
 
-server()
+const serverConfig = config.get('server')
+const { logger } = serverConfig
+
+server().catch((err) => {
+  logger.error(err)
+  process.exit(1)
+})
 

--- a/src/server.js
+++ b/src/server.js
@@ -22,13 +22,7 @@ const {
 } = serverConfig
 
 async function createServer() {
-  let db
-  try {
-    db = await createDB(config.get('db'))
-  } catch (err) {
-    logger.error(`Failed to connect to db: ${err}`)
-    throw err
-  }
+  const db = await createDB(config.get('db'))
   logger.info('Connected to db')
 
   const server = restify.createServer({
@@ -37,7 +31,10 @@ async function createServer() {
   })
 
   if (!disableHealthcheck) {
-    healthCheck(db)
+    healthCheck(db).catch((err) => {
+      logger.error(err)
+      process.exit(1)
+    })
   }
 
   const allowedOrigins = corsEnabledFor ? corsEnabledFor.split(',').map(x => x.trim()) : []


### PR DESCRIPTION
before this PR the server just exited with code 1 without logging anything. In this PR I added logging of the error when the server fails before exiting. I also refactored db connection creation error logging in healthcheck to a more general error handling (I catch the error from the promise related to the healthcheck subroutine)

Can be tested by throwing an arbitrary error in createServer function or mangling the db credentials in .env