### PR TITLE
Remove /api/txs/last endpoint

### DIFF
--- a/src/db-api.js
+++ b/src/db-api.js
@@ -106,17 +106,6 @@ const utxoLegacy = (db: Pool) => async (addresses: Array<string>): Promise<Resul
     values: [addresses],
   })
 
-  /**
-* Queries TXS table for the last 20 transactions
-* @param {Db Object} db
-*/
-const lastTxs = (db: Pool) => async (): Promise<ResultSet> =>
-  db.query({
-    text: `SELECT * FROM "txs"
-      ORDER BY "time" DESC
-      LIMIT 20`,
-  })
-
 const bestBlock = (db: Pool) => async (): Promise<number> => {
   const query = await db.query('SELECT * FROM "bestblock"')
   return query.rows.length > 0 ? parseInt(query.rows[0].best_block_num, 10) : 0
@@ -133,5 +122,4 @@ export default (db: Pool): DbApi => ({
   bulkAddressSummary: bulkAddressSummary(db),
   txSummary: txSummary(db),
   utxoLegacy: utxoLegacy(db),
-  lastTxs: lastTxs(db),
 })

--- a/src/legacy-routes.js
+++ b/src/legacy-routes.js
@@ -161,24 +161,6 @@ const unspentTxOutputs = (dbApi: any, { logger, apiConfig }: ServerConfig) => as
 }
 
 /**
- * This endpoint returns information about the last 20 transactions
- * @param {*} db Database
- * @param {*} Server Server Config Object
- */
-const lastTxs = (dbApi: any, { logger }: ServerConfig) => async () => {
-  const result = await dbApi.lastTxs()
-  const right = result.rows.map((row) => ({
-    cteId: row.hash,
-    cteTimeIssued: moment(row.time).unix(),
-    cteAmount: {
-      getCoin: arraySum(row.outputs_amount),
-    },
-  }))
-  logger.debug('[lastTxs] result calculated')
-  return { Right: right }
-}
-
-/**
  * This endpoint returns the list of addresses, the number of their transactions and the list of
  * transactions.
  * @param {*} db Database
@@ -229,11 +211,6 @@ export default {
     method: 'post',
     path: withPrefix('/bulk/addresses/utxo'),
     handler: unspentTxOutputs,
-  },
-  lastTxs: {
-    method: 'get',
-    path: withPrefix('/txs/last'),
-    handler: lastTxs,
   },
   bulkAddressSummary: {
     method: 'post',

--- a/src/middleware/response-guard.js
+++ b/src/middleware/response-guard.js
@@ -16,7 +16,7 @@ function shouldBlockRequest(req: any): boolean {
 
   if (req.url === '/api/v2/healthcheck') {
     return !instanceHealthStatus.healthy
-  } else if (['/api/v2/bestBlock', '/api/v2/healthStatus', '/api/txs/last'].includes(req.url)) {
+  } else if (['/api/v2/bestBlock', '/api/v2/healthStatus'].includes(req.url)) {
     // these requests are good to inspect the instance when it becomes unhealthy
     return false
   }


### PR DESCRIPTION
This PR is removing the `/api/txs/last` endpoint

Reason: The `/api/txs/last` endpoint is not needed for a wallet, it was just to mimick the API of the old cardanoexplorer and it was (mis)used to see if the database is syncing, but the `/api/v2/bestBlock` added later on, which shows the last available block is good enough for that.

This endpoint is currently a problem, because it makes a query on the `txs` table ordering by `time` which unfortunately is not indexed in the db schema created by the new importer (tangata-manu - see https://github.com/Emurgo/tangata-manu/blob/master/migrations/1551287652718_initial.js), so it takes a lot of time and overloads the db, so it can be abused to take down the service with little effort. We could update the tangata-manu migrations to have that index, but it's probably not worth it since wallets (i.e. adalite) do not need this endpoint.

closes #69 