### PR TITLE
Add tests for new db scheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "clean-test-db": "node ./scripts/test/clean_test_db.js",
     "transpile-tests": "babel ./test/ --out-dir ./build-test/",
     "unit-tests": "yarn build && yarn transpile-tests && mocha \"build-test/unit/**/*.js\"",
-    "integration-tests": "yarn transpile-tests && NODE_ENV=test yarn load-test-db && NODE_ENV=test mocha \"build-test/integration/**/*.js\"",
+    "integration-tests": "yarn transpile-tests && NODE_ENV=test yarn load-test-db && NODE_ENV=test mocha \"build-test/integration/legacy/**/*.js\"",
     "all-tests": "yarn unit-tests && yarn integration-tests",
     "coverage": "yarn all-tests",
     "postintegration-tests": "NODE_ENV=test yarn clean-test-db"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "clean-test-db": "node ./scripts/test/clean_test_db.js",
     "transpile-tests": "babel ./test/ --out-dir ./build-test/",
     "unit-tests": "yarn build && yarn transpile-tests && mocha \"build-test/unit/**/*.js\"",
-    "integration-tests": "yarn transpile-tests && NODE_ENV=test yarn load-test-db && NODE_ENV=test mocha \"build-test/integration/legacy/**/*.js\"",
+    "integration-tests": "yarn transpile-tests && NODE_ENV=test yarn load-test-db && NODE_ENV=test mocha \"build-test/integration/**/*.js\"",
     "all-tests": "yarn unit-tests && yarn integration-tests",
     "coverage": "yarn all-tests",
     "postintegration-tests": "NODE_ENV=test yarn clean-test-db"

--- a/test/integration/filter-used-addresses.integration-test.js
+++ b/test/integration/filter-used-addresses.integration-test.js
@@ -5,7 +5,10 @@ import { runInServer, assertOnResults } from './test-utils'
 // @flow
 // const shuffle = require('shuffle-array')
 
-const ENDPOINT = '/addresses/filterUsed'
+// To avoid Possible EventEmitter memory leak detected message
+process.setMaxListeners(0)
+
+const ENDPOINT = '/v2/addresses/filterUsed'
 
 describe('FilterUsedAddresses endpoint', () => {
   it('should return empty if addresses do not exist', async () =>
@@ -24,8 +27,8 @@ describe('FilterUsedAddresses endpoint', () => {
 
   it('should return used addresses just once', async () => {
     const usedAddresses = [
-      'DdzFFzCqrht4wFnWC5TJA5UUVE54JC9xZWq589iKyCrWa6hek3KKevyaXzQt6FsdunbkZGzBFQhwZi1MDpijwRoC7kj1MkEPh2Uu5Ssz',
-      'DdzFFzCqrht4wFnWC5TJA5UUVE54JC9xZWq589iKyCrWa6hek3KKevyaXzQt6FsdunbkZGzBFQhwZi1MDpijwRoC7kj1MkEPh2Uu5Ssz',
+      'DdzFFzCqrhsoavpTFBhT1EAo2dDbEr7CcS1925uCTqFbT1B81NdRZcaKM4tyrDfm29iYCym8FJo4BdvSM6rFtmgUCXq6Q8vz718niXp3',
+      'DdzFFzCqrhsoavpTFBhT1EAo2dDbEr7CcS1925uCTqFbT1B81NdRZcaKM4tyrDfm29iYCym8FJo4BdvSM6rFtmgUCXq6Q8vz718niXp3',
     ]
 
     return runInServer(api =>
@@ -39,10 +42,10 @@ describe('FilterUsedAddresses endpoint', () => {
 
   it('should filter unused addresses', async () => {
     const usedAddresses = [
-      'DdzFFzCqrht4wFnWC5TJA5UUVE54JC9xZWq589iKyCrWa6hek3KKevyaXzQt6FsdunbkZGzBFQhwZi1MDpijwRoC7kj1MkEPh2Uu5Ssz',
-      'DdzFFzCqrhtBBX4VvncQ6Zxn8UHawaqSB4jf9EELRBuWUT9gZTmCDWCNTVMotEdof1g26qbrDc8qcHZvtntxR4FaBN1iKxQ5ttjZSZoj',
-      'DdzFFzCqrhsvrpQgsnTxPsCAeEUcGTwxUtBv94F2jGGW8s3ZT7V2xPYBAL4renccQQv6bnVtuSr5a5N6cJuAh8Nw58dzZDJTesodN2kV',
-      'DdzFFzCqrht9eptGZnVrBCcoLn6fWJF4CS1Dvs8KCKutDXgQ9hdNTEPxFqWwfM3gwpVv3zrLQf7dV7xsUpxLPQKGagGX3CscjWeeTEXz',
+      'DdzFFzCqrhszp4fARmEMkgb99btzMKNuYnFMsQHXFZJyDPjPJuu3fi1JHCGgNgLSufYJaP6b7GMtTEprfmSzTQjKqJyneB75y5ABbiSf',
+      'DdzFFzCqrhswkXmoWjcFTDEB3AnAJSqcf7FPsjcesTGfu9zSmCc2Nn2aufdgoQ8zPxQHkdkqfixejHnQejVbm4MQCsd88dCywQqYZEEk',
+      'DdzFFzCqrht7tzd7P6aAWkqiF91p8vLSdBWdnTExD7prn7uojmbDdLVsKBs7hANQDSvGixzVeTTwQXaTqJ4LNLNDkNb69PVqxDZn4fCd',
+      'DdzFFzCqrht2M9W4v5ibT8PjjQCTWh6xSnVwaAGidiGRB1FbF6ZnzKx5V97wXthw5Gfo4L68JJZmNUAWUxjkPXojwHQF9uqxvGeC6wjG',
     ]
 
     const unusedAddresses = [

--- a/test/integration/healthcheck.integration-test.js
+++ b/test/integration/healthcheck.integration-test.js
@@ -5,7 +5,7 @@ describe('Healthcheck endpoint', () => {
   it('Should return package.json version', async () =>
     runInServer(api =>
       api
-        .get('/healthcheck')
+        .get('/v2/healthcheck')
         .expectValue('version', packageJson.version)
         .end(),
     ))

--- a/test/integration/legacy/bulk-address-summary-integration-test.js
+++ b/test/integration/legacy/bulk-address-summary-integration-test.js
@@ -1,0 +1,52 @@
+/* eslint-disable max-len */
+import { expect } from 'chai'
+// import shuffle from 'shuffle-array'
+import { runInServer, assertOnResults } from '../test-utils'
+
+const ENDPOINT = '/bulk/addresses/summary'
+
+describe('BulkAddressSummary endpoint', () => {
+  it('should return left if addresses are empty', async () =>
+    runInServer(api =>
+      api
+        .post(ENDPOINT)
+        .send()
+        .expectBody({ Left: 'Addresses request length should be (0, 50]' })
+        .end(),
+    ))
+
+  it('should return left if an address is invalid', async () =>
+    runInServer(api =>
+      api
+        .post(ENDPOINT)
+        .send([
+          'InvalidDdzFFzCqrhshvqw9GrHmSw6ySwViBj5cj2njWj5mbnLu4uNauJCKuXhHS3wNUoGRNBGGTkyTFDQNrUWMumZ3mxarAjoXiYvyhead7yKQ',
+          'DdzFFzCqrhshvqw9GrHmSw6ySwViBj5cj2njWj5mbnLu4uNauJCKuXhHS3wNUoGRNBGGTkyTFDQNrUWMumZ3mxarAjoXiYvyhead7yKQ',
+        ])
+        .expectBody({ Left: 'Invalid Cardano address!' })
+        .end(),
+    ))
+
+  it('should return empty if addresses do not exist', async () => {
+    const expectedAddressSummary = {
+      Right: {
+        caAddresses:
+          ['DdzFFzCqrhshvqw9GrHmSw6ySwViBj5cj2njWj5mbnLu4uNauJCKuXhHS3wNUoGRNBGGTkyTFDQNrUWMumZ3mxarAjoXiYvyhead7yKQ',
+            'DdzFFzCqrht7HGoJ87gznLktJGywK1LbAJT2sbd4txmgS7FcYLMQFhawb18ojS9Hx55mrbsHPr7PTraKh14TSQbGBPJHbDZ9QVh6Z6Di'],
+        caTxNum: 0,
+        caBalance: { getCoin: '0' },
+        caTxList: [],
+      },
+    }
+    return runInServer(api =>
+      api
+        .post(ENDPOINT)
+        .send([
+          'DdzFFzCqrhshvqw9GrHmSw6ySwViBj5cj2njWj5mbnLu4uNauJCKuXhHS3wNUoGRNBGGTkyTFDQNrUWMumZ3mxarAjoXiYvyhead7yKQ',
+          'DdzFFzCqrht7HGoJ87gznLktJGywK1LbAJT2sbd4txmgS7FcYLMQFhawb18ojS9Hx55mrbsHPr7PTraKh14TSQbGBPJHbDZ9QVh6Z6Di',
+        ])
+        .expectBody(expectedAddressSummary)
+        .end(),
+    )
+  })
+})

--- a/test/integration/legacy/bulk-addresses-utxo-integration-test.js
+++ b/test/integration/legacy/bulk-addresses-utxo-integration-test.js
@@ -1,0 +1,75 @@
+/* eslint-disable max-len */
+import { runInServer } from '../test-utils'
+
+const ENDPOINT = '/bulk/addresses/utxo'
+
+describe('UtxoForAddresses endpoint', () => {
+  it('should return left if addresses are empty', async () =>
+    runInServer(api =>
+      api
+        .post(ENDPOINT)
+        .send()
+        .expectBody({ Left: 'Addresses request length should be (0, 50]' })
+        .end(),
+    ))
+
+  it('should return left if an address is invalid', async () =>
+    runInServer(api =>
+      api
+        .post(ENDPOINT)
+        .send([
+          'InvalidDdzFFzCqrhshvqw9GrHmSw6ySwViBj5cj2njWj5mbnLu4uNauJCKuXhHS3wNUoGRNBGGTkyTFDQNrUWMumZ3mxarAjoXiYvyhead7yKQ',
+          'DdzFFzCqrhshvqw9GrHmSw6ySwViBj5cj2njWj5mbnLu4uNauJCKuXhHS3wNUoGRNBGGTkyTFDQNrUWMumZ3mxarAjoXiYvyhead7yKQ',
+        ])
+        .expectBody({ Left: 'Invalid Cardano address!' })
+        .end(),
+    ))
+
+  it('should return empty if addresses do not exist', async () =>
+    runInServer(api =>
+      api
+        .post(ENDPOINT)
+        .send([
+          'DdzFFzCqrhshvqw9GrHmSw6ySwViBj5cj2njWj5mbnLu4uNauJCKuXhHS3wNUoGRNBGGTkyTFDQNrUWMumZ3mxarAjoXiYvyhead7yKQ',
+          'DdzFFzCqrhshvqw9GrHmSw6ySwViBj5cj2njWj5mbnLu4uNauJCKuXhHS3wNUoGRNBGGTkyTFDQNrUWMumZ3mxarAjoXiYvyhead7yKQ',
+        ])
+        .expectBody({ Right: [] })
+        .end(),
+    ))
+
+  it('should return data for addresses balance once even if sent twice', async () => {
+    const usedAddresses = [
+      'DdzFFzCqrhsoavpTFBhT1EAo2dDbEr7CcS1925uCTqFbT1B81NdRZcaKM4tyrDfm29iYCym8FJo4BdvSM6rFtmgUCXq6Q8vz718niXp3',
+      'DdzFFzCqrhsoavpTFBhT1EAo2dDbEr7CcS1925uCTqFbT1B81NdRZcaKM4tyrDfm29iYCym8FJo4BdvSM6rFtmgUCXq6Q8vz718niXp3',
+    ]
+
+    const expectedUTOXs = {
+      Right: [{
+        tag: 'CUtxo',
+        cuId:
+          'ea8b8577cb8c4b0e88bee2ff29b4b512fe6469623edb470266e8f78ed6b00322',
+        cuOutIndex: 1,
+        cuAddress:
+          'DdzFFzCqrhsoavpTFBhT1EAo2dDbEr7CcS1925uCTqFbT1B81NdRZcaKM4tyrDfm29iYCym8FJo4BdvSM6rFtmgUCXq6Q8vz718niXp3',
+        cuCoins: { getCoin: '10000000' },
+      },
+      {
+        tag: 'CUtxo',
+        cuId:
+          '0ad85f6b0738d5ac3b02216c36b62b4d8ffc5d079aff4324d97744aa16cab8ea',
+        cuOutIndex: 1,
+        cuAddress:
+          'DdzFFzCqrhsoavpTFBhT1EAo2dDbEr7CcS1925uCTqFbT1B81NdRZcaKM4tyrDfm29iYCym8FJo4BdvSM6rFtmgUCXq6Q8vz718niXp3',
+        cuCoins: { getCoin: '330580600000' },
+      }],
+    }
+
+    return runInServer(api =>
+      api
+        .post(ENDPOINT)
+        .send(usedAddresses)
+        .expectBody(expectedUTOXs)
+        .end(),
+    )
+  })
+})

--- a/test/integration/test-utils.js
+++ b/test/integration/test-utils.js
@@ -7,7 +7,7 @@ import createServer from '../../build/server'
 function api(server): Hippie {
   return hippie(server)
     .json()
-    .base('http://localhost:8080/api/v2')
+    .base('http://localhost:8080/api')
 }
 
 /**

--- a/test/integration/transactions-history.integration-test.js
+++ b/test/integration/transactions-history.integration-test.js
@@ -3,10 +3,171 @@ import moment from 'moment'
 import shuffle from 'shuffle-array'
 import { runInServer, assertOnResults } from './test-utils'
 
-const ENDPOINT = '/txs/history'
+const ENDPOINT = '/v2/txs/history'
 
 // To avoid Possible EventEmitter memory leak detected message
 process.setMaxListeners(0)
+
+const expectedTxHistoryExample = [{
+  hash:
+    'e4c15e3db742a7e4221d8292b083594cb2fd2c500e35cc84b5c6dccf61f1e48a',
+  inputs_address:
+    ['DdzFFzCqrhsseB5YtzP1h11ttpzJ3EYVaLri1j2HsktAfKEWcxgdSgDoSpyp1j9ac4kHewFAaKKB6DRrd7NgdyuA5JvL2GDtCEcVTbSc'],
+  inputs_amount: ['403885460194'],
+  outputs_address:
+    ['DdzFFzCqrht6SJ6PHQnxzFkrqCVXxG2rfZLGgXyzV5e5LQyLy64TrGeWf3Gm3bRDzoDKJ3pmyj2SLdi4C6MVZqwmA9HsBmvDNP9XHYjc',
+      'DdzFFzCqrht37kjZfpjxNHScXnQoRVZMcsw3CrDXnfYCtcmHHfxYUzfn78KrvBDvibB4meDBMLpMdpkqtDMQahDHKECHostfqSSq7uD2'],
+  outputs_amount: ['303885288948', '100000000000'],
+
+  block_num: '33947',
+  block_hash:
+    '40f032cb0ce4d1428a510081fa64ecb2e1f0e4031db377dcd5fbba57a0f41dbd',
+  time: '2017-10-01T16:26:31.000Z',
+  tx_state: 'Successful',
+  last_update: '2017-10-01T16:26:31.000Z',
+  tx_body:
+    '839f8200d81858248258204ee029a099a3392fc50beac679e6da10c9d1da344142852af7ef36c34e47eb6000ff9f8282d818584283581ccbc02c411955743fe002eccd3f7771ebb2ccc8d480e2c595547aa948a101581e581cbe70075b69a5843a6223f43c9741414159781623a6eb19df8598a567001a4d2cac631b00000046c0f985f48282d818584283581cb26061350a0e8d79ffdd10a8db5ee3a45209988179a0ad497470af57a101581e581cca3e553c9c63c51a7d4be6439aecf5755fc6a9ea88c2190ad22644b1001a0b537ad91b000000174876e800ffa0',
+  tx_ordinal: 0,
+  inputs: [{
+    address:
+      'DdzFFzCqrhsseB5YtzP1h11ttpzJ3EYVaLri1j2HsktAfKEWcxgdSgDoSpyp1j9ac4kHewFAaKKB6DRrd7NgdyuA5JvL2GDtCEcVTbSc',
+    amount: '403885460194',
+    id:
+      '4ee029a099a3392fc50beac679e6da10c9d1da344142852af7ef36c34e47eb600',
+    index: 0,
+    txHash:
+      '4ee029a099a3392fc50beac679e6da10c9d1da344142852af7ef36c34e47eb60',
+  }],
+  best_block_num: '36119',
+},
+{
+  hash:
+    '44c076dc421227dca789554d10da42e95896881ff34e2168ce24a83bf9868cbf',
+  inputs_address:
+    ['DdzFFzCqrht6SJ6PHQnxzFkrqCVXxG2rfZLGgXyzV5e5LQyLy64TrGeWf3Gm3bRDzoDKJ3pmyj2SLdi4C6MVZqwmA9HsBmvDNP9XHYjc'],
+  inputs_amount: ['303885288948'],
+  outputs_address:
+    ['DdzFFzCqrhseZLwWkBfcf7w3hUyngK7QT5HEUTYEsFuMcoR2Y1ZhEBkvGQWPhgRLW6X7HJcgnbQ8djZWPP8iR3YXLYnK4LebRERKZDRE',
+      'DdzFFzCqrht37kjZfpjxNHScXnQoRVZMcsw3CrDXnfYCtcmHHfxYUzfn78KrvBDvibB4meDBMLpMdpkqtDMQahDHKECHostfqSSq7uD2'],
+  outputs_amount: ['153885117702', '150000000000'],
+  block_num: '33966',
+  block_hash:
+    '67fb1cc8e3451ba9a1544fcce5df268467d64f364f51706ee730bd43d394afcd',
+  time: '2017-10-01T16:32:51.000Z',
+  tx_state: 'Successful',
+  last_update: '2017-10-01T16:32:51.000Z',
+  tx_body:
+    '839f8200d8185824825820e4c15e3db742a7e4221d8292b083594cb2fd2c500e35cc84b5c6dccf61f1e48a00ff9f8282d818584283581c05f236beb4ca869ee3e94809386ec2cb56e96afee758a19d06c0c00da101581e581cbe70075b69a5847b640f343c3267bf703f096b7a4e26f7d6889534fd001a71842f8d1b00000023d4448d068282d818584283581cb26061350a0e8d79ffdd10a8db5ee3a45209988179a0ad497470af57a101581e581cca3e553c9c63c51a7d4be6439aecf5755fc6a9ea88c2190ad22644b1001a0b537ad91b00000022ecb25c00ffa0',
+  tx_ordinal: 2,
+  inputs: [{
+    address:
+      'DdzFFzCqrht6SJ6PHQnxzFkrqCVXxG2rfZLGgXyzV5e5LQyLy64TrGeWf3Gm3bRDzoDKJ3pmyj2SLdi4C6MVZqwmA9HsBmvDNP9XHYjc',
+    amount: '303885288948',
+    id:
+      'e4c15e3db742a7e4221d8292b083594cb2fd2c500e35cc84b5c6dccf61f1e48a0',
+    index: 0,
+    txHash:
+      'e4c15e3db742a7e4221d8292b083594cb2fd2c500e35cc84b5c6dccf61f1e48a',
+  }],
+  best_block_num: '36119',
+}]
+
+const usedAndUnusedHistory = [{
+  hash:
+    'ad1224bf89df3310504fcf6311865f8dc1459a6af283302df7a927945a565eef',
+  inputs_address:
+    ['DdzFFzCqrhsnqRJvYwPgrf6MG7GKg2iyABiG5QZpN5fTdnoGLYSfiLybttVsovWVmZKgQthLrKfQirfLzmpa3mEJHM1ywjk5V7qTWHFq'],
+  inputs_amount: ['82892096000000'],
+  outputs_address:
+    ['DdzFFzCqrhseyiRj2yMRWzcTMVBywt6cpYjby2mJKCFqapoifhSif2TVMsXdGx5JfZ87hcVbuJ8JtSZ9nQ53s4Zm1kEM23Xp9BzPa1Be',
+      'DdzFFzCqrhsnTrHkdrNAyvp2DtuXEsiVBe1mDF3h3BPEn7asRDQYx1e2VrgkeVnvDxcdUqnseeemix8EWXvme66ibu1LcnpYuXhECupo'],
+  outputs_amount: ['39814735357517', '43077360471237'],
+  block_num: '23671',
+  block_hash:
+    'c730fdb6985d86accdd353388c6cda38ba27ab9b70d8ae2d8484915ff7819c33',
+  time: '2017-09-29T07:19:31.000Z',
+  tx_state: 'Successful',
+  last_update: '2017-09-29T07:19:31.000Z',
+  tx_body:
+    '839f8200d8185824825820f79e8be4aa489c6ce5cdcdda703fa66bc763891623da1edda92d0c63bee124dc01ff9f8282d818584283581c092867f22d267cae0501bcea6b871777507241b0dd680f956f06ebdca101581e581ce0d687298a75b89c8b907d9b0727389293b9a2fa115e42ab7e403b2a001ac7964f111b000024361728664d8282d818584283581c425ef2629f2aca99754adf0c72512fcb687ce35ead58fe38a3ceb200a101581e581c9c126d30dc2b02b6f8a9580fbd09c2b6bece6dd150da310ac2348ccb001a71c91f2c1b0000272dbac4ccc5ffa0',
+  tx_ordinal: 0,
+  inputs:
+    [{
+      address:
+        'DdzFFzCqrhsnqRJvYwPgrf6MG7GKg2iyABiG5QZpN5fTdnoGLYSfiLybttVsovWVmZKgQthLrKfQirfLzmpa3mEJHM1ywjk5V7qTWHFq',
+      amount: '82892096000000',
+      id:
+        'f79e8be4aa489c6ce5cdcdda703fa66bc763891623da1edda92d0c63bee124dc1',
+      index: 1,
+      txHash:
+        'f79e8be4aa489c6ce5cdcdda703fa66bc763891623da1edda92d0c63bee124dc'
+    }],
+  best_block_num: '36119',
+},
+{
+  hash:
+    '854ccf1e7c03785e1a6cb63cd64dcc60664e0de5507b7c7ca68a67235f974e2c',
+  inputs_address:
+    ['DdzFFzCqrhseyiRj2yMRWzcTMVBywt6cpYjby2mJKCFqapoifhSif2TVMsXdGx5JfZ87hcVbuJ8JtSZ9nQ53s4Zm1kEM23Xp9BzPa1Be'],
+  inputs_amount: ['39814735357517'],
+  outputs_address:
+    ['DdzFFzCqrhst5P2ad1PTMeNV9rx2AkggPpxBmve7QS5wwsk8Y8NpLMDrSLs8eCL6DfgxBZFKveyd7aNZiutjq93dZe5xymyBfZ6JAWEv',
+      'DdzFFzCqrhswL73hsVsBoWtF9YUwxYSoHJgWTafoHXM5GUyJUmSTdsf48Kq11sQBY4YNvo2s1BJwtDXm7nd7mkxzb3BTh51FRzgttRNy'],
+  outputs_amount: ['30338506008364', '9476229177907'],
+  block_num: '23682',
+  block_hash:
+    'dddd162ce0aa08788246b672b6a2b05ba613e67feb7a3f0da5a10c3ce30f343a',
+  time: '2017-09-29T07:23:11.000Z',
+  tx_state: 'Successful',
+  last_update: '2017-09-29T07:23:11.000Z',
+  tx_body:
+    '839f8200d8185824825820ad1224bf89df3310504fcf6311865f8dc1459a6af283302df7a927945a565eef00ff9f8282d818584283581c6d456ef97f6b7903b7a650168e567f554eaad43efc5e1786ad9021bfa101581e581ce0d687298a75b8b63cf2649b87e0e2b47214bdee93a3db63bb85937a001ae98606d31b00001b97bbdfa72c8282d818584283581c86247a829b8a02f858ef0cad23ab7b6813b29245ced36b2d47f97a0ca101581e581cf6d34f1badb2687d25539e0d591ddc5eb6589173b1b56a390b26ee4a001a47893a221b0000089e5b462233ffa0',
+  tx_ordinal: 0,
+  inputs:
+    [{
+      address:
+        'DdzFFzCqrhseyiRj2yMRWzcTMVBywt6cpYjby2mJKCFqapoifhSif2TVMsXdGx5JfZ87hcVbuJ8JtSZ9nQ53s4Zm1kEM23Xp9BzPa1Be',
+      amount: '39814735357517',
+      id:
+        'ad1224bf89df3310504fcf6311865f8dc1459a6af283302df7a927945a565eef0',
+      index: 0,
+      txHash:
+        'ad1224bf89df3310504fcf6311865f8dc1459a6af283302df7a927945a565eef'
+    }],
+  best_block_num: '36119',
+},
+{
+  hash:
+    'a395ef658ccbe662a798dfc7596c1dae5a601aad32f81699290941e0824df726',
+  inputs_address:
+    ['DdzFFzCqrhtAeEuBmn8FGThzvQwChcakTrGume323jmwPs5nU4PURMLv7UbgqMrLqGMw8AX6jnfh83L57bfeMFsSi4UwaJoYwe7fBHtQ'],
+  inputs_amount: ['383069000000'],
+  outputs_address:
+    ['DdzFFzCqrhsuwnRg1KY28gErSuA4UB2wBsiQwFmtetjdA8UKEmxGpEkAhtQ9EWRJMbMdvZ4mqXfCNEWwDFutskRmon1MVZ2eY4cGtBAP',
+      'DdzFFzCqrhsi32aUzkACCxTudtkcvCWT8n41UUB8djQBaW26wsb6MoXHP4rzAdUGQeF7BJZGyz9NdS7sJ7zzL8skNMREb2rZr2HnNGWG'],
+  outputs_amount: ['62', '383068829000'],
+  block_num: '30719',
+  block_hash:
+    'b05a55f2c6ed351f2d053bfe298869c027070abbe93b57d4e1fb0d81f6773687',
+  time: '2017-09-30T22:29:51.000Z',
+  tx_state: 'Successful',
+  last_update: '2017-09-30T22:29:51.000Z',
+  tx_body:
+    '839f8200d81858248258204dc65dc59a0a86f869e4a5c814bc647cd5f9d398e17a5c72d4af3b73028ea0e300ff9f8282d818584283581c7b8eaab75057edf30704db089949bd1b15364f7e47a93b89b4448e31a101581e581cfd93bc946f90274df44289cbccfa8d5c21154221707a4abd992ba4c5001a48ee0b90183e8282d818584283581c20867527b823a22137ab0465833898e8a63420bf999835a0f9d778b9a101581e581cca3e553c9c63c5361a364f43f27b2894242ae462790816ff734a9801001a311d9d951b0000005930ae7548ffa0',
+  tx_ordinal: 0,
+  inputs:
+    [{
+      address:
+        'DdzFFzCqrhtAeEuBmn8FGThzvQwChcakTrGume323jmwPs5nU4PURMLv7UbgqMrLqGMw8AX6jnfh83L57bfeMFsSi4UwaJoYwe7fBHtQ',
+      amount: '383069000000',
+      id:
+        '4dc65dc59a0a86f869e4a5c814bc647cd5f9d398e17a5c72d4af3b73028ea0e30',
+      index: 0,
+      txHash:
+        '4dc65dc59a0a86f869e4a5c814bc647cd5f9d398e17a5c72d4af3b73028ea0e3'
+    }],
+  best_block_num: '36119',
+}]
 
 describe('Transaction History endpoint', () => {
   it('should return empty if addresses do not exist', async () =>
@@ -30,7 +191,7 @@ describe('Transaction History endpoint', () => {
         .post(ENDPOINT)
         .send({
           addresses: [
-            'DdzFFzCqrhsqFM8QxHC4ASk4QLfuoWqbY65GeprG8ezEY6VFkP4jz4C4fcDT57fkUUrPN8E2gaPXiWQxjD3BryptceQEx98ALsrYMoSi',
+            'DdzFFzCqrht37kjZfpjxNHScXnQoRVZMcsw3CrDXnfYCtcmHHfxYUzfn78KrvBDvibB4meDBMLpMdpkqtDMQahDHKECHostfqSSq7uD2',
           ],
           dateFrom: moment('2050-12-25').toISOString(),
         })
@@ -41,9 +202,9 @@ describe('Transaction History endpoint', () => {
   it('should return history for input and output addresses', async () => {
     const usedAddresses = [
       // Input and Output
-      'DdzFFzCqrhsgBCt25t6JArdDHfJZkzzebapE2qqrg1yoquLZzeEyxzhLAb9x7rVf5aby9jwLvL65hH9zTWjbekwzbeYCjJ5pUKn1rYgB',
+      'DdzFFzCqrhseyiRj2yMRWzcTMVBywt6cpYjby2mJKCFqapoifhSif2TVMsXdGx5JfZ87hcVbuJ8JtSZ9nQ53s4Zm1kEM23Xp9BzPa1Be',
       // Output
-      'DdzFFzCqrhsqFM8QxHC4ASk4QLfuoWqbY65GeprG8ezEY6VFkP4jz4C4fcDT57fkUUrPN8E2gaPXiWQxjD3BryptceQEx98ALsrYMoSi',
+      'DdzFFzCqrhsuwnRg1KY28gErSuA4UB2wBsiQwFmtetjdA8UKEmxGpEkAhtQ9EWRJMbMdvZ4mqXfCNEWwDFutskRmon1MVZ2eY4cGtBAP',
     ]
 
     return runInServer(api =>
@@ -53,92 +214,15 @@ describe('Transaction History endpoint', () => {
           addresses: usedAddresses,
           dateFrom: moment('1995-12-25').toISOString(),
         })
-        .expectBody([
-          {
-            hash: 'e1a958d42f7a064ef447feee5859fd45b8c925de825a7460819f67e8a4f320d0',
-            inputs_address: [
-              'DdzFFzCqrhsjRXHaGcwLdb82izDN3WNzJpyXnLQ2XPa7PKsuqVWbccKLHymdhgzys117xwosU7Kg8XrqHihHHJNNLDte6WrKq5zJ2Njk',
-              'DdzFFzCqrhsjRXHaGcwLdb82izDN3WNzJpyXnLQ2XPa7PKsuqVWbccKLHymdhgzys117xwosU7Kg8XrqHihHHJNNLDte6WrKq5zJ2Njk',
-            ],
-            inputs_amount: [
-              '10000000',
-              '10000000',
-            ],
-            outputs_address: [
-              'DdzFFzCqrhsqFM8QxHC4ASk4QLfuoWqbY65GeprG8ezEY6VFkP4jz4C4fcDT57fkUUrPN8E2gaPXiWQxjD3BryptceQEx98ALsrYMoSi',
-              'DdzFFzCqrhsxi87yX3WBKVJ37n7frUZjiVTwoc7qxdVeEAoqiRiLUecLngUhgYbc1hfTyzxtwvwSRtGNeWKJfaqMefs4dwybgHmwBj8c',
-            ],
-            outputs_amount: [
-              '4821151',
-              '15000000',
-            ],
-            block_num: '116147',
-            time: '2017-10-23T18:03:53.000Z',
-            tx_state: 'Successful',
-            last_update: '2018-07-13T20:06:04.197Z',
-            best_block_num: '1266738',
-          },
-          {
-            hash: 'a8fb2c6cce6d68ea4c65b8301eb26636178c40d3c65071e738d5a4e5cde4d91d',
-            inputs_address: [
-              'DdzFFzCqrht9SryvcbmahwFFbXkDGzDtuA26Qccf1nQ9bWPmkej9i7q6e9A2bbEVEs2szYJtUupPAQLbh9fANEh1zBLikREmL3XubFAr',
-            ],
-            inputs_amount: [
-              '96599520',
-            ],
-            outputs_address: [
-              'DdzFFzCqrhsgBCt25t6JArdDHfJZkzzebapE2qqrg1yoquLZzeEyxzhLAb9x7rVf5aby9jwLvL65hH9zTWjbekwzbeYCjJ5pUKn1rYgB',
-              'DdzFFzCqrhszk2XG2vdMcB3JhkpGTTnMeWvwoE5wHacAu1H38bp5Smr6pxEvJDk5KzeKsTaPSmBVJ24hp2FfqxGDdgH7hp1H1bt5U8Hk',
-              'DdzFFzCqrhszk2XG2vdMcB3JhkpGTTnMeWvwoE5wHacAu1H38bp5Smr6pxEvJDk5KzeKsTaPSmBVJ24hp2FfqxGDdgH7hp1H1bt5U8Hk',
-              'DdzFFzCqrhszk2XG2vdMcB3JhkpGTTnMeWvwoE5wHacAu1H38bp5Smr6pxEvJDk5KzeKsTaPSmBVJ24hp2FfqxGDdgH7hp1H1bt5U8Hk',
-            ],
-            outputs_amount: [
-              '96421943',
-              '1',
-              '1',
-              '1',
-            ],
-            block_num: '872076',
-            time: '2018-04-17T04:24:13.000Z',
-            tx_state: 'Successful',
-            last_update: '2018-07-13T21:08:55.778Z',
-            best_block_num: '1266738',
-          },
-          {
-            hash: 'de5dbbed46ef5c69f52b3a77ee74585bef07aebcd90383de28348159c697b568',
-            inputs_address: [
-              'DdzFFzCqrhsgBCt25t6JArdDHfJZkzzebapE2qqrg1yoquLZzeEyxzhLAb9x7rVf5aby9jwLvL65hH9zTWjbekwzbeYCjJ5pUKn1rYgB',
-            ],
-            inputs_amount: [
-              '96421943',
-            ],
-            outputs_address: [
-              'DdzFFzCqrhsrDmGpSbh2LBRmStmMyGznXaeBLoDMSKjLfRuf9DWpLMEzbXw9eQcFsSwNX5sunRuxsJnSZFbu8pTe1qLerrWwwiinEzVe',
-              'DdzFFzCqrhstXeWBtWKg1Z189XE5uwwwfbKeUHdacmnD1qMaNqs6Qk3ctZF1frH1wT5PnnJXzLC2fumc9qVWLFp9aMGPEfVzzL6eyKjM',
-              'DdzFFzCqrhstXeWBtWKg1Z189XE5uwwwfbKeUHdacmnD1qMaNqs6Qk3ctZF1frH1wT5PnnJXzLC2fumc9qVWLFp9aMGPEfVzzL6eyKjM',
-              'DdzFFzCqrhstXeWBtWKg1Z189XE5uwwwfbKeUHdacmnD1qMaNqs6Qk3ctZF1frH1wT5PnnJXzLC2fumc9qVWLFp9aMGPEfVzzL6eyKjM',
-            ],
-            outputs_amount: [
-              '96244366',
-              '1',
-              '1',
-              '1',
-            ],
-            block_num: '872089',
-            time: '2018-04-17T04:28:33.000Z',
-            tx_state: 'Successful',
-            last_update: '2018-07-13T21:08:55.794Z',
-            best_block_num: '1266738',
-          },
-        ])
+        .expectBody(usedAndUnusedHistory)
         .end(),
     )
   })
 
   it('should history once even if addresses sent twice', async () => {
     const usedAddresses = [
-      'DdzFFzCqrhsqFM8QxHC4ASk4QLfuoWqbY65GeprG8ezEY6VFkP4jz4C4fcDT57fkUUrPN8E2gaPXiWQxjD3BryptceQEx98ALsrYMoSi',
-      'DdzFFzCqrhsqFM8QxHC4ASk4QLfuoWqbY65GeprG8ezEY6VFkP4jz4C4fcDT57fkUUrPN8E2gaPXiWQxjD3BryptceQEx98ALsrYMoSi',
+      'DdzFFzCqrht6SJ6PHQnxzFkrqCVXxG2rfZLGgXyzV5e5LQyLy64TrGeWf3Gm3bRDzoDKJ3pmyj2SLdi4C6MVZqwmA9HsBmvDNP9XHYjc',
+      'DdzFFzCqrht6SJ6PHQnxzFkrqCVXxG2rfZLGgXyzV5e5LQyLy64TrGeWf3Gm3bRDzoDKJ3pmyj2SLdi4C6MVZqwmA9HsBmvDNP9XHYjc',
     ]
 
     return runInServer(api =>
@@ -148,34 +232,14 @@ describe('Transaction History endpoint', () => {
           addresses: usedAddresses,
           dateFrom: moment('1995-12-25').toISOString(),
         })
-        .expectBody([
-          {
-            hash:
-              'e1a958d42f7a064ef447feee5859fd45b8c925de825a7460819f67e8a4f320d0',
-            inputs_address: [
-              'DdzFFzCqrhsjRXHaGcwLdb82izDN3WNzJpyXnLQ2XPa7PKsuqVWbccKLHymdhgzys117xwosU7Kg8XrqHihHHJNNLDte6WrKq5zJ2Njk',
-              'DdzFFzCqrhsjRXHaGcwLdb82izDN3WNzJpyXnLQ2XPa7PKsuqVWbccKLHymdhgzys117xwosU7Kg8XrqHihHHJNNLDte6WrKq5zJ2Njk',
-            ],
-            inputs_amount: ['10000000', '10000000'],
-            outputs_address: [
-              'DdzFFzCqrhsqFM8QxHC4ASk4QLfuoWqbY65GeprG8ezEY6VFkP4jz4C4fcDT57fkUUrPN8E2gaPXiWQxjD3BryptceQEx98ALsrYMoSi',
-              'DdzFFzCqrhsxi87yX3WBKVJ37n7frUZjiVTwoc7qxdVeEAoqiRiLUecLngUhgYbc1hfTyzxtwvwSRtGNeWKJfaqMefs4dwybgHmwBj8c',
-            ],
-            outputs_amount: ['4821151', '15000000'],
-            block_num: '116147',
-            time: '2017-10-23T18:03:53.000Z',
-            best_block_num: '1266738',
-            tx_state: 'Successful',
-            last_update: '2018-07-13T20:06:04.197Z',
-          },
-        ])
+        .expectBody(expectedTxHistoryExample)
         .end(),
     )
   })
 
   it('should history once even if addresses is present in input and output', async () => {
     const usedAddresses = [
-      'CYhGP86nCaiEEEUSLWTS3gvAzmLTWM8Nj5CuJyqg5y2iJ1jNhwrZWsNE9n9xsmk5HFDa6DdZcPoXTUEYKddVsqJ1Y',
+      'DdzFFzCqrhsh29QQ8S5xfjQeGaEiyz3AMdpeafE2cm5sFhYp54RqEErHmwHXUG2Kv2Ho7JKfvTfFHSEKxCmuPaTzRRiiEkTcZeketmeX',
     ]
 
     return runInServer(api =>
@@ -188,7 +252,7 @@ describe('Transaction History endpoint', () => {
         .expect(
           assertOnResults((res, body) => {
             // https://explorer.iohkdev.io/address/CYhGP86nCaiEEEUSLWTS3gvAzmLTWM8Nj5CuJyqg5y2iJ1jNhwrZWsNE9n9xsmk5HFDa6DdZcPoXTUEYKddVsqJ1Y
-            expect(body.length).to.equal(3)
+            expect(body.length).to.equal(2)
           }),
         )
         .end(),
@@ -197,7 +261,7 @@ describe('Transaction History endpoint', () => {
 
   it('should filter unused addresses', async () => {
     const usedAddresses = [
-      'DdzFFzCqrhsqFM8QxHC4ASk4QLfuoWqbY65GeprG8ezEY6VFkP4jz4C4fcDT57fkUUrPN8E2gaPXiWQxjD3BryptceQEx98ALsrYMoSi',
+      'DdzFFzCqrht6SJ6PHQnxzFkrqCVXxG2rfZLGgXyzV5e5LQyLy64TrGeWf3Gm3bRDzoDKJ3pmyj2SLdi4C6MVZqwmA9HsBmvDNP9XHYjc',
     ]
 
     const unusedAddresses = [
@@ -211,34 +275,15 @@ describe('Transaction History endpoint', () => {
       api
         .post(ENDPOINT)
         .send({ addresses, dateFrom: moment('1995-12-25').toISOString() })
-        .expectBody([
-          {
-            hash:
-              'e1a958d42f7a064ef447feee5859fd45b8c925de825a7460819f67e8a4f320d0',
-            inputs_address: [
-              'DdzFFzCqrhsjRXHaGcwLdb82izDN3WNzJpyXnLQ2XPa7PKsuqVWbccKLHymdhgzys117xwosU7Kg8XrqHihHHJNNLDte6WrKq5zJ2Njk',
-              'DdzFFzCqrhsjRXHaGcwLdb82izDN3WNzJpyXnLQ2XPa7PKsuqVWbccKLHymdhgzys117xwosU7Kg8XrqHihHHJNNLDte6WrKq5zJ2Njk',
-            ],
-            inputs_amount: ['10000000', '10000000'],
-            outputs_address: [
-              'DdzFFzCqrhsqFM8QxHC4ASk4QLfuoWqbY65GeprG8ezEY6VFkP4jz4C4fcDT57fkUUrPN8E2gaPXiWQxjD3BryptceQEx98ALsrYMoSi',
-              'DdzFFzCqrhsxi87yX3WBKVJ37n7frUZjiVTwoc7qxdVeEAoqiRiLUecLngUhgYbc1hfTyzxtwvwSRtGNeWKJfaqMefs4dwybgHmwBj8c',
-            ],
-            outputs_amount: ['4821151', '15000000'],
-            block_num: '116147',
-            time: '2017-10-23T18:03:53.000Z',
-            best_block_num: '1266738',
-            last_update: '2018-07-13T20:06:04.197Z',
-            tx_state: 'Successful',
-          },
-        ])
+        .expectBody(expectedTxHistoryExample)
         .end(),
     )
   })
 
   it('should paginate responses', async () => {
     const addresses = [
-      'DdzFFzCqrhsjyFvzVsaahmL93VEno1PRkXxUFqJAxRpA52VAyTHVKRGBFyGvGQmr9Ya8kiQF4bmXqTqMZ8G84Krp4xmHkJSvt6txEMXA',
+      'DdzFFzCqrhtCKmk5cs1Tagi8QWGsWy3xNZ31AsEUpSidYaofsX2KQBoHuK7ZoEFLdtH9Lb12Bhtou1AnYqRihdYBgKgtNwJ676bLpkJb',
+      'DdzFFzCqrhsmuwTVdRNuUMoYS1bVYXRcTyzYso1kYzdj1pWAswugkFnkjAEXAVohkXXnBCJXwURwNc92iQN2JX942QS2CUWcfXsSDb9g',
     ]
 
     let lastDateFrom
@@ -252,7 +297,7 @@ describe('Transaction History endpoint', () => {
             expect(body.length).to.equal(20)
             const lastElem = body[body.length - 1]
             expect(lastElem.hash).to.equal(
-              'a3f8d071d027b44571fc9dd50d17edb8c55768d8a7cb8a6709256f146d228ca8',
+              'dbea47d320454987ff82c472c12b986588182ba6f5a7089a9c319d2a60dfb611',
             )
             lastDateFrom = lastElem.last_update
           }),
@@ -270,9 +315,9 @@ describe('Transaction History endpoint', () => {
         })
         .expect(
           assertOnResults((res, body) => {
-            expect(body.length).to.equal(20)
+            expect(body.length).to.equal(5)
             expect(body[0].hash).to.equal(
-              'a3f8d071d027b44571fc9dd50d17edb8c55768d8a7cb8a6709256f146d228ca8',
+              'dbea47d320454987ff82c472c12b986588182ba6f5a7089a9c319d2a60dfb611',
             )
           }),
         )

--- a/test/integration/utxo-for-addresses.integration-test.js
+++ b/test/integration/utxo-for-addresses.integration-test.js
@@ -2,7 +2,10 @@ import { expect } from 'chai'
 import shuffle from 'shuffle-array'
 import { runInServer, assertOnResults } from './test-utils'
 
-const ENDPOINT = '/txs/utxoForAddresses'
+const ENDPOINT = '/v2/txs/utxoForAddresses'
+
+// To avoid Possible EventEmitter memory leak detected message
+process.setMaxListeners(0)
 
 describe('UtxoForAddresses endpoint', () => {
   it('should return empty if addresses do not exist', async () =>
@@ -21,34 +24,33 @@ describe('UtxoForAddresses endpoint', () => {
 
   it('should return data for addresses balance once even if sent twice', async () => {
     const usedAddresses = [
-      'DdzFFzCqrhshvqw9GrHmSw6ySwViBj5cj2njWj5mbnLu4uNauJCKuXhHS3wNUoGRNBGGTkyTFDQNrUWMumZ3mxarAjoXiYvyhead7yKQ',
-      'DdzFFzCqrhshvqw9GrHmSw6ySwViBj5cj2njWj5mbnLu4uNauJCKuXhHS3wNUoGRNBGGTkyTFDQNrUWMumZ3mxarAjoXiYvyhead7yKQ',
+      'DdzFFzCqrhswkXmoWjcFTDEB3AnAJSqcf7FPsjcesTGfu9zSmCc2Nn2aufdgoQ8zPxQHkdkqfixejHnQejVbm4MQCsd88dCywQqYZEEk',
+      'DdzFFzCqrhswkXmoWjcFTDEB3AnAJSqcf7FPsjcesTGfu9zSmCc2Nn2aufdgoQ8zPxQHkdkqfixejHnQejVbm4MQCsd88dCywQqYZEEk',
     ]
 
     return runInServer(api =>
       api
         .post(ENDPOINT)
         .send({ addresses: usedAddresses })
-        .expectBody([
-          {
-            utxo_id:
-              '6cc6d736e3a4395acabfae4c7cfe409b65d8c7c6bbf9ff85a0bd4a95334b7a5f0',
-            tx_hash:
-              '6cc6d736e3a4395acabfae4c7cfe409b65d8c7c6bbf9ff85a0bd4a95334b7a5f',
-            tx_index: 0,
-            receiver:
-              'DdzFFzCqrhshvqw9GrHmSw6ySwViBj5cj2njWj5mbnLu4uNauJCKuXhHS3wNUoGRNBGGTkyTFDQNrUWMumZ3mxarAjoXiYvyhead7yKQ',
-            amount: '1463071700828754',
-          },
-        ])
+        .expectBody([{
+          utxo_id:
+            '2afb190a0b9fe21cb014d5b21ae5321fbb1585cee9a34a9ae87aba05a46472650',
+          tx_hash:
+            '2afb190a0b9fe21cb014d5b21ae5321fbb1585cee9a34a9ae87aba05a4647265',
+          tx_index: 0,
+          receiver:
+            'DdzFFzCqrhswkXmoWjcFTDEB3AnAJSqcf7FPsjcesTGfu9zSmCc2Nn2aufdgoQ8zPxQHkdkqfixejHnQejVbm4MQCsd88dCywQqYZEEk',
+          amount: '390053000000',
+          block_num: 27654,
+        }])
         .end(),
     )
   })
 
   it('should filter unused addresses', async () => {
     const usedAddresses = [
-      'DdzFFzCqrhshvqw9GrHmSw6ySwViBj5cj2njWj5mbnLu4uNauJCKuXhHS3wNUoGRNBGGTkyTFDQNrUWMumZ3mxarAjoXiYvyhead7yKQ',
-      'DdzFFzCqrhskrzzPrXynkZ3gteGy8GmWYrswqz9SueoFP9PV5suFnGv9sQqg3o5pxzFpDTJ2HFJzHrThxBYarQi8guzMUhuiePB1T6ff',
+      'DdzFFzCqrht7tzd7P6aAWkqiF91p8vLSdBWdnTExD7prn7uojmbDdLVsKBs7hANQDSvGixzVeTTwQXaTqJ4LNLNDkNb69PVqxDZn4fCd',
+      'DdzFFzCqrht59BgECpEq8Xtnw95Yz1y1vnLC9kBAh7rr6dcBM2pEfV9nfJoKSCn59uRMPW89xoLSRCaXGehbVzYDVp4CnQmepLE8trrs',
     ]
 
     const unusedAddresses = [
@@ -57,28 +59,28 @@ describe('UtxoForAddresses endpoint', () => {
       'DdzFFzCqrht8d5FeU62PpBw1e3JLUP48LKfDfNtUyfuBJjBEqmgfYpwcbNHCh3csA4DEzu7SYquoUdmkcknR1E1D6zz5byvpMx632VJx',
     ]
 
-    const expectedUTOXs = [
-      {
-        utxo_id:
-          '6cc6d736e3a4395acabfae4c7cfe409b65d8c7c6bbf9ff85a0bd4a95334b7a5f0',
-        tx_hash:
-          '6cc6d736e3a4395acabfae4c7cfe409b65d8c7c6bbf9ff85a0bd4a95334b7a5f',
-        tx_index: 0,
-        receiver:
-          'DdzFFzCqrhshvqw9GrHmSw6ySwViBj5cj2njWj5mbnLu4uNauJCKuXhHS3wNUoGRNBGGTkyTFDQNrUWMumZ3mxarAjoXiYvyhead7yKQ',
-        amount: '1463071700828754',
-      },
-      {
-        utxo_id:
-          'aba9ad6b8360542698038dea31ca23037ad933c057abc18c5c17c2c63dbc3d131',
-        tx_hash:
-          'aba9ad6b8360542698038dea31ca23037ad933c057abc18c5c17c2c63dbc3d13',
-        tx_index: 1,
-        receiver:
-          'DdzFFzCqrhskrzzPrXynkZ3gteGy8GmWYrswqz9SueoFP9PV5suFnGv9sQqg3o5pxzFpDTJ2HFJzHrThxBYarQi8guzMUhuiePB1T6ff',
-        amount: '9829100',
-      },
-    ]
+    const expectedUTOXs = [{
+      utxo_id:
+        '6f63d6bac05093a44712aa6cd0e94d63793a370ffd50bb3f61a0a1ed6fb3482c0',
+      tx_hash:
+        '6f63d6bac05093a44712aa6cd0e94d63793a370ffd50bb3f61a0a1ed6fb3482c',
+      tx_index: 0,
+      receiver:
+        'DdzFFzCqrht7tzd7P6aAWkqiF91p8vLSdBWdnTExD7prn7uojmbDdLVsKBs7hANQDSvGixzVeTTwQXaTqJ4LNLNDkNb69PVqxDZn4fCd',
+      amount: '390384000000',
+      block_num: 27655,
+    },
+    {
+      utxo_id:
+        '71d2b2fa15d7976e6dabb44e5fcc52eaddb9143271e0f39d26d1e8c29d2172f10',
+      tx_hash:
+        '71d2b2fa15d7976e6dabb44e5fcc52eaddb9143271e0f39d26d1e8c29d2172f1',
+      tx_index: 0,
+      receiver:
+        'DdzFFzCqrht59BgECpEq8Xtnw95Yz1y1vnLC9kBAh7rr6dcBM2pEfV9nfJoKSCn59uRMPW89xoLSRCaXGehbVzYDVp4CnQmepLE8trrs',
+      amount: '2619215000000',
+      block_num: 27656,
+    }]
 
     const addresses = shuffle(usedAddresses.concat(unusedAddresses))
     return runInServer(api =>

--- a/test/integration/utxo-sum-for-addresses.integration-test.js
+++ b/test/integration/utxo-sum-for-addresses.integration-test.js
@@ -1,7 +1,7 @@
 import shuffle from 'shuffle-array'
 import { runInServer } from './test-utils'
 
-const ENDPOINT = '/txs/utxoSumForAddresses'
+const ENDPOINT = '/v2/txs/utxoSumForAddresses'
 
 describe('UtxoSumForAddresses endpoint', () => {
   it('should return empty if addresses do not exist', async () =>
@@ -20,22 +20,22 @@ describe('UtxoSumForAddresses endpoint', () => {
 
   it('should sum addresses balance once even if sent twice', async () => {
     const usedAddresses = [
-      'DdzFFzCqrht4wFnWC5TJA5UUVE54JC9xZWq589iKyCrWa6hek3KKevyaXzQt6FsdunbkZGzBFQhwZi1MDpijwRoC7kj1MkEPh2Uu5Ssz',
-      'DdzFFzCqrht4wFnWC5TJA5UUVE54JC9xZWq589iKyCrWa6hek3KKevyaXzQt6FsdunbkZGzBFQhwZi1MDpijwRoC7kj1MkEPh2Uu5Ssz',
+      'DdzFFzCqrhswkXmoWjcFTDEB3AnAJSqcf7FPsjcesTGfu9zSmCc2Nn2aufdgoQ8zPxQHkdkqfixejHnQejVbm4MQCsd88dCywQqYZEEk',
+      'DdzFFzCqrhswkXmoWjcFTDEB3AnAJSqcf7FPsjcesTGfu9zSmCc2Nn2aufdgoQ8zPxQHkdkqfixejHnQejVbm4MQCsd88dCywQqYZEEk',
     ]
 
     return runInServer(api =>
       api
         .post(ENDPOINT)
         .send({ addresses: usedAddresses })
-        .expectValue('sum', '621894750')
+        .expectValue('sum', '390053000000')
         .end(),
     )
   })
 
   it('should filter unused addresses', async () => {
     const usedAddresses = [
-      'DdzFFzCqrht4wFnWC5TJA5UUVE54JC9xZWq589iKyCrWa6hek3KKevyaXzQt6FsdunbkZGzBFQhwZi1MDpijwRoC7kj1MkEPh2Uu5Ssz',
+      'DdzFFzCqrhswkXmoWjcFTDEB3AnAJSqcf7FPsjcesTGfu9zSmCc2Nn2aufdgoQ8zPxQHkdkqfixejHnQejVbm4MQCsd88dCywQqYZEEk',
     ]
 
     const unusedAddresses = [
@@ -49,7 +49,7 @@ describe('UtxoSumForAddresses endpoint', () => {
       api
         .post(ENDPOINT)
         .send({ addresses })
-        .expectValue('sum', '621894750')
+        .expectValue('sum', '390053000000')
         .end(),
     )
   })

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -37,12 +37,10 @@ describe('Routes', () => {
   // This returns fake data. It's ok if they are not real objects (for example utxo or txs)
   // as we are checking the response is being returned, not the queries
   const dbApi = {
-    filterUsedAddresses: sinon.fake.resolves({ rows: [['a1', 'a2']] }),
-    utxoForAddresses: sinon.fake.resolves({ rows: ['utxo1', 'utxo2'] }),
-    utxoSumForAddresses: sinon.fake.resolves({ rows: [10, 20] }),
-    transactionsHistoryForAddresses: sinon.fake.resolves({
-      rows: ['tx1', 'tx2'],
-    }),
+    filterUsedAddresses: sinon.fake.resolves([['a1', 'a2']]),
+    utxoForAddresses: sinon.fake.resolves(['utxo1', 'utxo2']),
+    utxoSumForAddresses: sinon.fake.resolves([10, 20]),
+    transactionsHistoryForAddresses: sinon.fake.resolves(['tx1', 'tx2']),
     unspentAddresses: sinon.fake.resolves([]),
   }
 

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -3,6 +3,7 @@ import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import sinon from 'sinon'
 import Bunyan from 'bunyan'
+import type { UtxoForAddressesDbResult } from 'icarus-backend' // eslint-disable-line
 import { InternalServerError, BadRequestError } from 'restify-errors'
 import packageJson from '../../package.json'
 import routes from '../../build/routes'
@@ -33,12 +34,21 @@ function mockAxiosError(response) {
   return result
 }
 
+const initUtxo = (txHash, txIndex, receiver, amount, blockNum): UtxoForAddressesDbResult => ({
+  tx_hash: txHash,
+  tx_index: txIndex,
+  receiver,
+  amount,
+  block_num: blockNum,
+})
+
 describe('Routes', () => {
-  // This returns fake data. It's ok if they are not real objects (for example utxo or txs)
+  // This returns fake data. It's ok if they are not real objects (for example txs)
   // as we are checking the response is being returned, not the queries
+  // Utxo requires concrete values due to key appending in endpoint functionality
   const dbApi = {
     filterUsedAddresses: sinon.fake.resolves([['a1', 'a2']]),
-    utxoForAddresses: sinon.fake.resolves(['utxo1', 'utxo2']),
+    utxoForAddresses: sinon.fake.resolves([initUtxo('hash1', 0, 'addr1', 100, 1), initUtxo('hash2', 1, 'addr2', 100, 1)]),
     utxoSumForAddresses: sinon.fake.resolves([10, 20]),
     transactionsHistoryForAddresses: sinon.fake.resolves(['tx1', 'tx2']),
     unspentAddresses: sinon.fake.resolves([]),
@@ -136,7 +146,13 @@ describe('Routes', () => {
       const response = await handler({
         body: { addresses: Array(20).fill('an_address') },
       })
-      return expect(response).to.eql(['utxo1', 'utxo2'])
+      return expect(response).to.eql([{
+        utxo_id: 'hash10',
+        ...initUtxo('hash1', 0, 'addr1', 100, 1),
+      }, {
+        utxo_id: 'hash21',
+        ...initUtxo('hash2', 1, 'addr2', 100, 1),
+      }])
     })
   })
 


### PR DESCRIPTION
Adds test for some legacy endpoints which were previously missing, and also updates the old tests for new DB scheme. 
Replaces the old db scheme with the new one. There could be more tests for the legacy endpoints but I decided to not spend a lot amount of time with this since I expect the db-dump to be changed once again after Shelley is released so all the test will probably have to be redone anyway. Either way, open to suggestions. (PeterBenc)