### PR TITLE
Fix cardano-submit-api image reference to point to a stable version

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -46,7 +46,7 @@ services:
 
   cardano-node:
     container_name: ${COMPOSE_PROJECT_NAME}-cardano-node
-    image: inputoutput/cardano-node:master
+    image: refi93/cardano-node:byron
     environment:
       - NETWORK=${NETWORK}
     volumes:
@@ -77,7 +77,7 @@ services:
 
   cardano-submit-api:
     container_name: ${COMPOSE_PROJECT_NAME}-cardano-submit-api
-    image: inputoutput/cardano-submit-api:master
+    image: refi93/cardano-submit-api:byron
     environment:
       - NETWORK=${NETWORK}
     depends_on:


### PR DESCRIPTION
We've got a report from @roccomuso that the recently updated master tag of cardano-submit-api (https://hub.docker.com/layers/inputoutput/cardano-submit-api/master/images/sha256-c08361d147d47e03bf86a70289ac27d16a36a5f6bb558c529a64e0f5b9b270bc?context=explore) is breaking their infrastructure

I checked cardano-rest repo and they switched to the "latest" tag and added a config variable to override the version if needed (https://github.com/input-output-hk/cardano-rest/blob/6bd244b9277970ae9ec6000555da4ae423670950/docker-compose.yml#L81) so I'm mirroring the changes here