### PR TITLE
Alegra versions fix and submit api upgrade to 3.1.1

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -90,7 +90,7 @@ services:
 
   cardano-submit-api:
     container_name: ${COMPOSE_PROJECT_NAME}-cardano-submit-api
-    image: inputoutput/cardano-submit-api:3.1.0
+    image: inputoutput/cardano-submit-api:3.1.1
     environment:
       - NETWORK=${NETWORK}
     depends_on:

--- a/src/routes.js
+++ b/src/routes.js
@@ -187,7 +187,7 @@ const signedTransaction = (
   let response
   try {
     const tx: string = req.body.signedTx
-    response = await importerApi.sendTx(Buffer.from(tx, 'base64').toString('hex'))
+    response = await importerApi.sendTx(Buffer.from(tx, 'base64'))
     return response.data
   } catch (err) {
     if (err.response && err.response.status < 500 && err.response.data) {


### PR DESCRIPTION
The toString('hex') was causing the error `"message":"Provided data was hex encoded and this webapi expects raw binary"`